### PR TITLE
Remove cross SBT building for scripted task

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ jobs:
     - stage: test
       if: (NOT branch =~ /^release\/.*$/)
       # When running scripted tests targeting multiple SBT versions, we must first publish locally for all SBT versions
-      script: sbt "^ publishLocal" "^ scripted"
+      script: sbt "^ publishLocal" "scripted"
     - stage: release
       if: (branch =~ /^release\/.*$/)
       env:

--- a/release.sbt
+++ b/release.sbt
@@ -12,7 +12,7 @@ releaseProcess := Seq[ReleaseStep](
   releaseStepCommandAndRemaining("^ test"),
   // When running scripted tests targeting multiple SBT versions, we must first publish locally for all SBT versions
   releaseStepCommandAndRemaining("^ publishLocal"),
-  releaseStepCommandAndRemaining("^ scripted"),
+  releaseStepInputTask(scripted),
   setReleaseVersion,
   commitReleaseVersion,
   // don't tag, leave it to git flow


### PR DESCRIPTION
There is no need to cross build `scripted` task as the SBT version it will run with depends on the version configured in the scripted test's `project/build.properties` file. This will greatly reduce build times.