### PR TITLE
Update SBT to 1.3.3

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -32,7 +32,7 @@ developers := List(
 
 crossSbtVersions := Seq(
   "0.13.17",
-  "1.2.6"
+  "1.3.3"
 )
 
 libraryDependencies ++= Seq(

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version = 1.2.6
+sbt.version = 1.3.3

--- a/src/sbt-test/sbt-1.0/testFailure/project/build.properties
+++ b/src/sbt-test/sbt-1.0/testFailure/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version = 1.2.6
+sbt.version = 1.3.3

--- a/src/sbt-test/sbt-1.0/testFailure/project/plugins.sbt
+++ b/src/sbt-test/sbt-1.0/testFailure/project/plugins.sbt
@@ -3,3 +3,5 @@ sys.props.get("plugin.version") match {
   case _ => sys.error("""|The system property 'plugin.version' is not defined.
                          |Specify this property using the scriptedLaunchOpts -D.""".stripMargin)
 }
+
+useCoursier := false

--- a/src/sbt-test/sbt-1.0/testFailure/src/sbt-test/basic/simple/project/build.properties
+++ b/src/sbt-test/sbt-1.0/testFailure/src/sbt-test/basic/simple/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version = 1.2.6
+sbt.version = 1.3.3

--- a/src/sbt-test/sbt-1.0/testFailure/src/sbt-test/basic/simple/project/plugins.sbt
+++ b/src/sbt-test/sbt-1.0/testFailure/src/sbt-test/basic/simple/project/plugins.sbt
@@ -3,3 +3,5 @@ sys.props.get("plugin.version") match {
   case _ => sys.error("""|The system property 'plugin.version' is not defined.
                          |Specify this property using the scriptedLaunchOpts -D.""".stripMargin)
 }
+
+useCoursier := false


### PR DESCRIPTION
`useCoursier := false` is required in `scripted` tests due to issue with Coursier in SBT 1.3 (see sbt/sbt#5227)