### PR TITLE
Update scalatest dependency version to 3.1.0

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -36,5 +36,5 @@ crossSbtVersions := Seq(
 )
 
 libraryDependencies ++= Seq(
-  "org.scalatest" %% "scalatest" % "3.0.0"
+  "org.scalatest" %% "scalatest" % "3.1.0"
 )

--- a/src/main/scala/org/scalatest/ScriptedScalaTestSuite.scala
+++ b/src/main/scala/org/scalatest/ScriptedScalaTestSuite.scala
@@ -63,6 +63,7 @@ trait ScriptedScalaTestSuite extends Suite {
           false,
           false,
           false,
+          false,
           false
         )
       )

--- a/src/sbt-test/sbt-0.13/testFailure/build.sbt
+++ b/src/sbt-test/sbt-0.13/testFailure/build.sbt
@@ -1,6 +1,6 @@
 import com.github.daniel.shuy.sbt.scripted.scalatest.ScriptedScalaTestSuiteMixin
 import org.scalatest.Assertions._
-import org.scalatest.WordSpec
+import org.scalatest.wordspec.AnyWordSpec
 
 lazy val testFailure = project
   .in(file("."))
@@ -18,7 +18,7 @@ lazy val testFailure = project
     scriptedBufferLog := false,
 
     scriptedScalaTestStacks := SbtScriptedScalaTest.FullStacks,
-    scriptedScalaTestSpec := Some(new WordSpec with ScriptedScalaTestSuiteMixin {
+    scriptedScalaTestSpec := Some(new AnyWordSpec with ScriptedScalaTestSuiteMixin {
       override val sbtState: State = state.value
 
       "scripted" should {

--- a/src/sbt-test/sbt-0.13/testFailure/src/sbt-test/basic/simple/build.sbt
+++ b/src/sbt-test/sbt-0.13/testFailure/src/sbt-test/basic/simple/build.sbt
@@ -1,6 +1,6 @@
 import com.github.daniel.shuy.sbt.scripted.scalatest.ScriptedScalaTestSuiteMixin
 import org.scalatest.Assertions._
-import org.scalatest.WordSpec
+import org.scalatest.wordspec.AnyWordSpec
 
 lazy val testBasicSimple = project
   .in(file("."))
@@ -8,7 +8,7 @@ lazy val testBasicSimple = project
     name := "test/basic/simple",
 
     scriptedScalaTestStacks := SbtScriptedScalaTest.FullStacks,
-    scriptedScalaTestSpec := Some(new WordSpec with ScriptedScalaTestSuiteMixin {
+    scriptedScalaTestSpec := Some(new AnyWordSpec with ScriptedScalaTestSuiteMixin {
       override val sbtState: State = state.value
 
       "scripted test" should {

--- a/src/sbt-test/sbt-1.0/testFailure/build.sbt
+++ b/src/sbt-test/sbt-1.0/testFailure/build.sbt
@@ -1,6 +1,6 @@
 import com.github.daniel.shuy.sbt.scripted.scalatest.ScriptedScalaTestSuiteMixin
 import org.scalatest.Assertions._
-import org.scalatest.WordSpec
+import org.scalatest.wordspec.AnyWordSpec
 
 lazy val testFailure = project
   .in(file("."))
@@ -18,7 +18,7 @@ lazy val testFailure = project
     scriptedBufferLog := false,
 
     scriptedScalaTestStacks := SbtScriptedScalaTest.FullStacks,
-    scriptedScalaTestSpec := Some(new WordSpec with ScriptedScalaTestSuiteMixin {
+    scriptedScalaTestSpec := Some(new AnyWordSpec with ScriptedScalaTestSuiteMixin {
       override val sbtState: State = state.value
 
       "scripted" should {

--- a/src/sbt-test/sbt-1.0/testFailure/src/sbt-test/basic/simple/build.sbt
+++ b/src/sbt-test/sbt-1.0/testFailure/src/sbt-test/basic/simple/build.sbt
@@ -1,6 +1,6 @@
 import com.github.daniel.shuy.sbt.scripted.scalatest.ScriptedScalaTestSuiteMixin
 import org.scalatest.Assertions._
-import org.scalatest.WordSpec
+import org.scalatest.wordspec.AnyWordSpec
 
 lazy val testBasicSimple = project
   .in(file("."))
@@ -8,7 +8,7 @@ lazy val testBasicSimple = project
     name := "test/basic/simple",
 
     scriptedScalaTestStacks := SbtScriptedScalaTest.FullStacks,
-    scriptedScalaTestSpec := Some(new WordSpec with ScriptedScalaTestSuiteMixin {
+    scriptedScalaTestSpec := Some(new AnyWordSpec with ScriptedScalaTestSuiteMixin {
       override val sbtState: State = state.value
 
       "scripted test" should {


### PR DESCRIPTION
Constructor definition for [StandardOutReporter](https://github.com/scalatest/scalatest/blob/release-3.1.0/scalatest/src/main/scala/org/scalatest/tools/StandardOutReporter.scala) was modified in ScalaTest `3.1.0`