### PR TITLE
Fix SbtScriptedScalaTest

### DIFF
--- a/src/sbt-test/sbt-1.0/testFailure/build.sbt
+++ b/src/sbt-test/sbt-1.0/testFailure/build.sbt
@@ -1,3 +1,5 @@
+import scala.sys.process._
+
 import com.github.daniel.shuy.sbt.scripted.scalatest.ScriptedScalaTestSuiteMixin
 import org.scalatest.Assertions._
 import org.scalatest.wordspec.AnyWordSpec
@@ -23,6 +25,9 @@ lazy val testFailure = project
 
       "scripted" should {
         "fail on ScalaTest failure" in {
+          val pidFile = new File("target/pid")
+          (s"echo ${ProcessHandle.current.pid}" #> pidFile).!!
+
           assertThrows[sbt.Incomplete](
             Project.extract(sbtState)
               .runInputTask(scripted, "", sbtState))

--- a/src/sbt-test/sbt-1.0/testFailure/test
+++ b/src/sbt-test/sbt-1.0/testFailure/test
@@ -1,1 +1,3 @@
+$ delete target/pid
 > scriptedScalatest
+$ exists target/pid


### PR DESCRIPTION
It was broken by https://github.com/adRise/scripted-scalatest-sbt-plugin/commit/4528e065bfbe05f81b6a578288fc76bbde981ff0. `executeScriptedTestsTask` just created a `Def.Intialize[Task[Unit]]`, and dropped it.